### PR TITLE
Replace legacy react-quill with react-quill-new and refactor ticket UI (memoized message bubble + traffic status)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,6 @@
         "react": "^19.0.1",
         "react-dom": "^19.0.1",
         "react-markdown": "^10.1.0",
-        "react-quill": "^2.0.0",
         "react-quill-new": "^3.8.3",
         "tailwind-merge": "^3.5.0",
         "vite": "^6.2.3"
@@ -1613,15 +1612,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/quill": {
-      "version": "1.3.10",
-      "resolved": "https://registry.npmjs.org/@types/quill/-/quill-1.3.10.tgz",
-      "integrity": "sha512-IhW3fPW+bkt9MLNlycw8u8fWb7oO7W5URC9MfZYHBlA24rex9rs23D5DETChu1zvgVdc5ka64ICjJOgQMr6Shw==",
-      "license": "MIT",
-      "dependencies": {
-        "parchment": "^1.1.2"
-      }
-    },
     "node_modules/@types/range-parser": {
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
@@ -1928,24 +1918,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/call-bind": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.9.tgz",
-      "integrity": "sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==",
-      "license": "MIT",
-      "dependencies": {
-        "call-bind-apply-helpers": "^1.0.2",
-        "es-define-property": "^1.0.1",
-        "get-intrinsic": "^1.3.0",
-        "set-function-length": "^1.2.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/call-bind-apply-helpers": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
@@ -2043,15 +2015,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/clone": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
-      "integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8"
       }
     },
     "node_modules/clsx": {
@@ -2171,60 +2134,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/deep-equal": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.1.2.tgz",
-      "integrity": "sha512-5tdhKF6DbU7iIzrIOa1AOUt39ZRm13cmL1cGEh//aqR8x9+tNfbywRf0n5FD/18OKMdo7DNEtrX2t22ZAkI+eg==",
-      "license": "MIT",
-      "dependencies": {
-        "is-arguments": "^1.1.1",
-        "is-date-object": "^1.0.5",
-        "is-regex": "^1.1.4",
-        "object-is": "^1.1.5",
-        "object-keys": "^1.1.1",
-        "regexp.prototype.flags": "^1.5.1"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/define-data-property": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
-      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
-      "license": "MIT",
-      "dependencies": {
-        "es-define-property": "^1.0.0",
-        "es-errors": "^1.3.0",
-        "gopd": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/define-properties": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
-      "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
-      "license": "MIT",
-      "dependencies": {
-        "define-data-property": "^1.0.1",
-        "has-property-descriptors": "^1.0.0",
-        "object-keys": "^1.1.1"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/depd": {
@@ -2451,12 +2360,6 @@
       "engines": {
         "node": ">= 0.6"
       }
-    },
-    "node_modules/eventemitter3": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-2.0.3.tgz",
-      "integrity": "sha512-jLN68Dx5kyFHaePoXWPsCGW5qdyZQtLYHkxkg02/Mz6g0kYpDx4FyP6XfArhQdlOC4b8Mv+EMxPo/8La7Tzghg==",
-      "license": "MIT"
     },
     "node_modules/express": {
       "version": "4.22.1",
@@ -2698,15 +2601,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/functions-have-names": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
-      "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/gaxios": {
       "version": "7.1.4",
       "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.1.4.tgz",
@@ -2838,38 +2732,11 @@
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "license": "ISC"
     },
-    "node_modules/has-property-descriptors": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
-      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
-      "license": "MIT",
-      "dependencies": {
-        "es-define-property": "^1.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/has-symbols": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
       "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/has-tostringtag": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
-      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
-      "license": "MIT",
-      "dependencies": {
-        "has-symbols": "^1.0.3"
-      },
       "engines": {
         "node": ">= 0.4"
       },
@@ -3029,38 +2896,6 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
-    "node_modules/is-arguments": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.2.0.tgz",
-      "integrity": "sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA==",
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.2",
-        "has-tostringtag": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/is-date-object": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.1.0.tgz",
-      "integrity": "sha512-PwwhEakHVKTdRNVOw+/Gyh0+MzlCl4R6qKvkhuvLtPMggI1WAHt9sOwZxQLSGpUaDnrdyDsomoRgNnCfKNSXXg==",
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.2",
-        "has-tostringtag": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/is-decimal": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-2.0.1.tgz",
@@ -3091,24 +2926,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/is-regex": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
-      "integrity": "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==",
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.2",
-        "gopd": "^1.2.0",
-        "has-tostringtag": "^1.0.2",
-        "hasown": "^2.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/jiti": {
@@ -3428,12 +3245,6 @@
         "type": "opencollective",
         "url": "https://opencollective.com/parcel"
       }
-    },
-    "node_modules/lodash": {
-      "version": "4.18.1",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
-      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
-      "license": "MIT"
     },
     "node_modules/lodash-es": {
       "version": "4.18.1",
@@ -4291,31 +4102,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/object-is": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.6.tgz",
-      "integrity": "sha512-F8cZ+KfGlSGi09lJT7/Nd6KJZ9ygtvYC0/UYYLI9nmQKLMnydpB9yvbv9K1uSkEu7FU9vYPmVwLg328tX+ot3Q==",
-      "license": "MIT",
-      "dependencies": {
-        "call-bind": "^1.0.7",
-        "define-properties": "^1.2.1"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/object-keys": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
-      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
     "node_modules/on-finished": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
@@ -4340,12 +4126,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/parchment": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/parchment/-/parchment-1.1.4.tgz",
-      "integrity": "sha512-J5FBQt/pM2inLzg4hEWmzQx/8h8D0CiDxaG3vyp9rKrQRSDgBlhjdP5jQGgosEajXPSQouXGHOmVdgo7QmJuOg==",
-      "license": "BSD-3-Clause"
     },
     "node_modules/parse-entities": {
       "version": "4.0.2",
@@ -4515,20 +4295,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/quill": {
-      "version": "1.3.7",
-      "resolved": "https://registry.npmjs.org/quill/-/quill-1.3.7.tgz",
-      "integrity": "sha512-hG/DVzh/TiknWtE6QmWAF/pxoZKYxfe3J/d/+ShUWkDvvkZQVTPeVmUJVu1uE6DDooC4fWTiCLh84ul89oNz5g==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "clone": "^2.1.1",
-        "deep-equal": "^1.0.1",
-        "eventemitter3": "^2.0.3",
-        "extend": "^3.0.2",
-        "parchment": "^1.1.4",
-        "quill-delta": "^3.6.2"
-      }
-    },
     "node_modules/quill-delta": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/quill-delta/-/quill-delta-5.1.0.tgz",
@@ -4541,26 +4307,6 @@
       },
       "engines": {
         "node": ">= 12.0.0"
-      }
-    },
-    "node_modules/quill/node_modules/fast-diff": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.1.2.tgz",
-      "integrity": "sha512-KaJUt+M9t1qaIteSvjc6P3RbMdXsNhK61GRftR6SNxqmhthcd9MGIi4T+o0jD8LUSpSnSKXE20nLtJ3fOHxQig==",
-      "license": "Apache-2.0"
-    },
-    "node_modules/quill/node_modules/quill-delta": {
-      "version": "3.6.3",
-      "resolved": "https://registry.npmjs.org/quill-delta/-/quill-delta-3.6.3.tgz",
-      "integrity": "sha512-wdIGBlcX13tCHOXGMVnnTVFtGRLoP0imqxM696fIPwIf5ODIYUHIvHbZcyvGlZFiFhK5XzDC2lpjbxRhnM05Tg==",
-      "license": "MIT",
-      "dependencies": {
-        "deep-equal": "^1.0.1",
-        "extend": "^3.0.2",
-        "fast-diff": "1.1.2"
-      },
-      "engines": {
-        "node": ">=0.10"
       }
     },
     "node_modules/range-parser": {
@@ -4635,21 +4381,6 @@
         "react": ">=18"
       }
     },
-    "node_modules/react-quill": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/react-quill/-/react-quill-2.0.0.tgz",
-      "integrity": "sha512-4qQtv1FtCfLgoD3PXAur5RyxuUbPXQGOHgTlFie3jtxp43mXDtzCKaOgQ3mLyZfi1PUlyjycfivKelFhy13QUg==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/quill": "^1.3.10",
-        "lodash": "^4.17.4",
-        "quill": "^1.3.7"
-      },
-      "peerDependencies": {
-        "react": "^16 || ^17 || ^18",
-        "react-dom": "^16 || ^17 || ^18"
-      }
-    },
     "node_modules/react-quill-new": {
       "version": "3.8.3",
       "resolved": "https://registry.npmjs.org/react-quill-new/-/react-quill-new-3.8.3.tgz",
@@ -4699,26 +4430,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/regexp.prototype.flags": {
-      "version": "1.5.4",
-      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz",
-      "integrity": "sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==",
-      "license": "MIT",
-      "dependencies": {
-        "call-bind": "^1.0.8",
-        "define-properties": "^1.2.1",
-        "es-errors": "^1.3.0",
-        "get-proto": "^1.0.1",
-        "gopd": "^1.2.0",
-        "set-function-name": "^2.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/remark-parse": {
@@ -4916,38 +4627,6 @@
       },
       "engines": {
         "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/set-function-length": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
-      "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
-      "license": "MIT",
-      "dependencies": {
-        "define-data-property": "^1.1.4",
-        "es-errors": "^1.3.0",
-        "function-bind": "^1.1.2",
-        "get-intrinsic": "^1.2.4",
-        "gopd": "^1.0.1",
-        "has-property-descriptors": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/set-function-name": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/set-function-name/-/set-function-name-2.0.2.tgz",
-      "integrity": "sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ==",
-      "license": "MIT",
-      "dependencies": {
-        "define-data-property": "^1.1.4",
-        "es-errors": "^1.3.0",
-        "functions-have-names": "^1.2.3",
-        "has-property-descriptors": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
       }
     },
     "node_modules/setprototypeof": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "react": "^19.0.1",
     "react-dom": "^19.0.1",
     "react-markdown": "^10.1.0",
-    "react-quill": "^2.0.0",
     "react-quill-new": "^3.8.3",
     "tailwind-merge": "^3.5.0",
     "vite": "^6.2.3"

--- a/src/components/TicketChat.tsx
+++ b/src/components/TicketChat.tsx
@@ -1,8 +1,43 @@
-import { useState, useRef, useEffect, lazy, Suspense } from 'react';
+import { useState, useRef, useEffect, lazy, Suspense, memo, useCallback } from 'react';
 import { Send, Bot, User, Loader2 } from 'lucide-react';
 import { TicketAnalysis, chatAboutTicket, ChatMessage } from '../services/ai';
 import { cn } from '../lib/utils';
 const Markdown = lazy(() => import('react-markdown'));
+
+const MessageBubble = memo(function MessageBubble({ msg }: { msg: ChatMessage }) {
+  return (
+    <div className={cn('flex gap-3', msg.role === 'user' ? 'justify-end' : 'justify-start')}>
+      {msg.role === 'model' && (
+        <div className="w-8 h-8 rounded-full bg-indigo-100 flex items-center justify-center shrink-0">
+          <Bot className="w-4 h-4 text-indigo-600" />
+        </div>
+      )}
+
+      <div
+        className={cn(
+          'max-w-[80%] rounded-2xl px-4 py-3 text-sm shadow-sm',
+          msg.role === 'user'
+            ? 'bg-indigo-600 text-white rounded-tr-none'
+            : 'bg-white border border-gray-100 text-gray-800 rounded-tl-none markdown-body prose prose-sm max-w-none'
+        )}
+      >
+        {msg.role === 'user' ? (
+          msg.content
+        ) : (
+          <Suspense fallback={<span className="animate-pulse">...</span>}>
+            <Markdown>{msg.content}</Markdown>
+          </Suspense>
+        )}
+      </div>
+
+      {msg.role === 'user' && (
+        <div className="w-8 h-8 rounded-full bg-gray-200 flex items-center justify-center shrink-0">
+          <User className="w-4 h-4 text-gray-500" />
+        </div>
+      )}
+    </div>
+  );
+});
 
 export function TicketChat({ result, rawContent }: { result: TicketAnalysis, rawContent: string }) {
   const [messages, setMessages] = useState<ChatMessage[]>([]);
@@ -14,7 +49,7 @@ export function TicketChat({ result, rawContent }: { result: TicketAnalysis, raw
     endOfMessagesRef.current?.scrollIntoView({ behavior: 'smooth' });
   }, [messages, isLoading]);
 
-  const handleSend = async () => {
+  const handleSend = useCallback(async () => {
     if (!input.trim() || isLoading) return;
 
     const userMessage = input.trim();
@@ -31,7 +66,7 @@ export function TicketChat({ result, rawContent }: { result: TicketAnalysis, raw
     } finally {
       setIsLoading(false);
     }
-  };
+  }, [input, isLoading, rawContent, result, messages]);
 
   return (
     <div className="flex flex-col h-[500px] bg-white border border-gray-200 rounded-xl shadow-sm overflow-hidden">
@@ -53,34 +88,7 @@ export function TicketChat({ result, rawContent }: { result: TicketAnalysis, raw
           </div>
         )}
         
-        {messages.map((msg, idx) => (
-          <div key={idx} className={cn("flex gap-3", msg.role === 'user' ? "justify-end" : "justify-start")}>
-            {msg.role === 'model' && (
-              <div className="w-8 h-8 rounded-full bg-indigo-100 flex items-center justify-center shrink-0">
-                <Bot className="w-4 h-4 text-indigo-600" />
-              </div>
-            )}
-            
-            <div className={cn(
-              "max-w-[80%] rounded-2xl px-4 py-3 text-sm shadow-sm",
-              msg.role === 'user' 
-                ? "bg-indigo-600 text-white rounded-tr-none" 
-                : "bg-white border border-gray-100 text-gray-800 rounded-tl-none markdown-body prose prose-sm max-w-none"
-            )}>
-              {msg.role === 'user' ? msg.content : (
-                <Suspense fallback={<span className="animate-pulse">...</span>}>
-                  <Markdown>{msg.content}</Markdown>
-                </Suspense>
-              )}
-            </div>
-
-            {msg.role === 'user' && (
-              <div className="w-8 h-8 rounded-full bg-gray-200 flex items-center justify-center shrink-0">
-                <User className="w-4 h-4 text-gray-500" />
-              </div>
-            )}
-          </div>
-        ))}
+        {messages.map((msg, idx) => <MessageBubble key={idx} msg={msg} />)}
         
         {isLoading && (
           <div className="flex gap-3 justify-start">

--- a/src/components/analysis/TicketHeader.tsx
+++ b/src/components/analysis/TicketHeader.tsx
@@ -3,6 +3,12 @@ import { TicketAnalysis } from '../../services/ai';
 import { AlertTriangle, Tag, Smile, Frown, Meh, PencilLine, Undo2, Save, CheckCircle, Info } from 'lucide-react';
 import { cn } from '../../lib/utils';
 
+type TrafficStatus = {
+  label: 'Red' | 'Amber' | 'Green';
+  classes: string;
+  description: string;
+};
+
 export function TicketHeader({
   result,
   priorities,
@@ -64,6 +70,44 @@ export function TicketHeader({
 
   const sentimentDisplay = getSentimentDisplay();
 
+  const getTrafficStatus = (): TrafficStatus => {
+    const priority = result.priority.toLowerCase();
+    const sentiment = result.sentiment.toLowerCase();
+    const escalation = result.escalationDecision.toLowerCase();
+
+    const isRed =
+      priority.includes('critical') ||
+      sentiment.includes('frustrat') ||
+      sentiment.includes('angr') ||
+      escalation.includes('escalat');
+
+    if (isRed) {
+      return {
+        label: 'Red',
+        classes: 'bg-rose-50 text-rose-700 border-rose-200',
+        description: 'High risk ticket. Immediate action recommended.'
+      };
+    }
+
+    const isAmber = priority.includes('high') || priority.includes('medium') || sentiment.includes('neutral');
+
+    if (isAmber) {
+      return {
+        label: 'Amber',
+        classes: 'bg-amber-50 text-amber-700 border-amber-200',
+        description: 'Moderate risk ticket. Handle soon and monitor.'
+      };
+    }
+
+    return {
+      label: 'Green',
+      classes: 'bg-emerald-50 text-emerald-700 border-emerald-200',
+      description: 'Low risk ticket. Standard response is sufficient.'
+    };
+  };
+
+  const trafficStatus = getTrafficStatus();
+
   return (
     <>
       {/* Ticket Title */}
@@ -121,7 +165,20 @@ export function TicketHeader({
       </section>
 
       {/* Top Banner - Key Stats */}
-      <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+      <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-4 gap-4">
+        {/* Traffic Status */}
+        <div className="bg-white border border-gray-200 rounded-xl p-4 shadow-sm flex items-center justify-between">
+          <div className="flex flex-col">
+            <span className="text-sm text-gray-500 font-medium">Ticket Status</span>
+            <span className={cn('mt-1 px-2.5 py-0.5 rounded-full text-xs font-semibold border w-max inline-flex items-center gap-1.5', trafficStatus.classes)}>
+              <span className={cn('h-2 w-2 rounded-full', trafficStatus.label === 'Red' ? 'bg-rose-500' : trafficStatus.label === 'Amber' ? 'bg-amber-500' : 'bg-emerald-500')} />
+              {trafficStatus.label}
+            </span>
+            <span className="mt-1 text-xs text-gray-500">{trafficStatus.description}</span>
+          </div>
+          <div className={cn('h-8 w-8 rounded-full border-2', trafficStatus.label === 'Red' ? 'border-rose-300 bg-rose-100' : trafficStatus.label === 'Amber' ? 'border-amber-300 bg-amber-100' : 'border-emerald-300 bg-emerald-100')} />
+        </div>
+
         {/* Priority */}
         <div className="bg-white border border-gray-200 rounded-xl p-4 shadow-sm flex items-center justify-between">
           <div className="flex flex-col flex-1 gap-1">


### PR DESCRIPTION
### Motivation

- Remove the old `react-quill` dependency and its transitive Quill v1 artifacts in favor of `react-quill-new` (Quill v2) to simplify dependency tree and avoid legacy packages. 
- Improve chat rendering performance and readability by extracting a memoized message component and stabilizing the send handler. 
- Surface a simple ticket risk/traffic indicator to help agents triage tickets at-a-glance.

### Description

- Removed `react-quill` from `package.json` and updated `package-lock.json`, which also removed legacy `quill` v1 and many related transitive packages. 
- Added a memoized `MessageBubble` component in `src/components/TicketChat.tsx` and replaced the previous inline message rendering with `messages.map((msg) => <MessageBubble ... />)` to reduce re-renders. 
- Wrapped the send logic with `useCallback` (`handleSend`) and kept lazy `react-markdown` rendering inside `Suspense` to ensure smooth UI updates and deferred markdown parsing. 
- Introduced a `TrafficStatus` type and `getTrafficStatus` function in `src/components/analysis/TicketHeader.tsx`, added a new traffic status card and adjusted the top banner grid layout to include the ticket status display and styling. 

### Testing

- Ran `npm ci` to install dependencies and the install completed successfully. 
- Ran `npm run lint` (which executes `tsc --noEmit`) and type checks passed with no errors. 
- Ran `npm run build` (`vite build`) and the production build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a032fe1632c832dae582f71865fdbb9)